### PR TITLE
Removes invalid SFN choice state output

### DIFF
--- a/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
+++ b/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
@@ -1049,14 +1049,13 @@
               "Type": "Choice",
               "Choices": [
                 {
-                  "Next": "Update purple gene",
-                  "Condition": "{% $payload.version > '2026' %}",
-                  "Output": {}
+                  "Next": "Update purple gene key",
+                  "Condition": "{% $payload.version > '2026' %}"
                 }
               ],
               "Default": "sash output placeholder"
             },
-            "Update purple gene": {
+            "Update purple gene key": {
               "Type": "Pass",
               "End": true,
               "Output": "{% $states.input ~> | $ | { 'cnGeneTsv': purpleGeneTsv }, ['purpleGeneTsv'] | %}"


### PR DESCRIPTION
Addresses an issue where an invalid `Output` field was present within a Step Function's choice state conditional branch. Removing this ensures correct workflow execution without unintended output.

Also updates the `Update purple gene` state name to `Update purple gene key` for improved clarity and consistency within the Step Function definition.